### PR TITLE
78 define word token separators

### DIFF
--- a/DeezyMatch/data_processing.py
+++ b/DeezyMatch/data_processing.py
@@ -105,11 +105,13 @@ def csv_split_tokenize(dataset_path, pretrained_vocab_path=None, n_train_example
     dataset_split["s1_unicode"] = dataset_split["s1_unicode"].apply(lambda x: string_split(x, 
                                                                                            tokenize=mode["tokenize"], 
                                                                                            min_gram=mode["min_gram"], 
-                                                                                           max_gram=mode["max_gram"]))
+                                                                                           max_gram=mode["max_gram"],
+                                                                                           sep = mode["sep"]))
     dataset_split["s2_unicode"] = dataset_split["s2_unicode"].apply(lambda x: string_split(x, 
                                                                                            tokenize=mode["tokenize"], 
                                                                                            min_gram=mode["min_gram"], 
-                                                                                           max_gram=mode["max_gram"]))
+                                                                                           max_gram=mode["max_gram"],
+                                                                                           sep = mode["sep"]))
 
     s1_s2_flatten = dataset_split[["s1_unicode", "s2_unicode"]].to_numpy().flatten()
     s1_s2_flatten_all_tokens = np.unique(np.hstack(s1_s2_flatten)).tolist()

--- a/DeezyMatch/utils.py
+++ b/DeezyMatch/utils.py
@@ -83,7 +83,7 @@ def eval_map(list_of_list_of_labels,list_of_list_of_scores,randomize=True):
 
 
 # ------------------- string_split --------------------
-def string_split(x, tokenize=["char"], min_gram=1, max_gram=3):
+def string_split(x, tokenize=["char"], min_gram=1, max_gram=3, sep=""):
     """
     Split a string using various methods.
     min_gram and max_gram are used only if "ngram" is in tokenize
@@ -97,7 +97,7 @@ def string_split(x, tokenize=["char"], min_gram=1, max_gram=3):
             tokenized_str += [x[i:i+ngram] for i in range(len(x)-ngram+1)] 
     
     if "word" in tokenize:
-        tokenized_str += x.split()
+        tokenized_str += x.split(separator=sep)
     
     return tokenized_str
    

--- a/inputs/input_dfm.yaml
+++ b/inputs/input_dfm.yaml
@@ -32,6 +32,8 @@ gru_lstm:
     # ONLY if "ngram" is selected in tokenize, the following args will be used:
     min_gram: 2
     max_gram: 3
+    # ONLY if "word" is selected in tokenize, the following arg (separator) will be used:
+    sep: "-"
   bidirectional: True    # if True, becomes a bidirectional RNN/GRU/LSTM
   # num_layers
   # number of recurrent layers. e.g., setting num_layers=2 means stacking two 


### PR DESCRIPTION
Allow the user to specify which characters should be considered when tokenizing, specifically "-" (issue #78 Define word token separator in the input file)